### PR TITLE
Add link to discussion "Single-sourcing the Project Version" in writing-pyproject.toml

### DIFF
--- a/source/guides/writing-pyproject-toml.rst
+++ b/source/guides/writing-pyproject-toml.rst
@@ -110,8 +110,8 @@ similar. In such cases, you should mark the field as dynamic using, e.g.,
 
 
 When a field is dynamic, it is the build backend's responsibility to
-fill it.  Consult your build backend's documentation to learn how it
-does it.
+fill it.  Consult :ref:`Single sourcing the version discussion` for more
+details.
 
 
 Basic information


### PR DESCRIPTION
This pull request adds a link to the discussion "Single-sourcing the Project Version" in the `writing-pyproject.toml` file. The link provides more details on how to mark a field as dynamic and fill it using the build backend's documentation.

Relevant to pypa/packaging.python.org#1276

<!-- readthedocs-preview python-packaging-user-guide start -->
----
📚 Documentation preview 📚: https://python-packaging-user-guide--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview python-packaging-user-guide end -->